### PR TITLE
Update the token issue URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export async function login(page: Page, clientNumber: string, accessCode: string
   await page.click('#login-btn')
 
   const authToken = await page
-    .waitForResponse('https://www.ing.com.au/STSServiceB2C/V1/SecurityTokenServiceProxy.svc/issue')
+    .waitForResponse('https://www.ing.com.au/api/token/login/issue')
     .then(res => res.json() as Promise<TokenResponse>)
     .then(data => data.Token)
 


### PR DESCRIPTION
Last time I tried (about a month ago) it was the old URL, but now I need to use this new URL to get the token.